### PR TITLE
Rework REST parameter prep

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,8 +1,7 @@
 1. Cmdlets should follow the [approved verbs list](https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands) to maintain consistency (e.g. `Get-XoTask`, `Get-XoVM`, `New-XoVMSnapshot` etc.)
 2. `SkipCertificateCheck` should be explicitly specified per session or per user.
 3. Session connection should be explicitly made with cmdlets like `Connect-XenOrchestra` and `Disconnect-XenOrchestra` for automation.
-4. Module-level variables should not be globals (e.g. by using `$Script:VariableName`).
-5. All cmdlets should have "native PowerShell" documentation, accessible via Get-Help (with `.SYNOPSIS`, `.DESCRIPTION`, comments/parameter constraints, `Validate` and `ArgumentCompletions` etc.).
-6. Cmdlet output should be pipelineable (e.g. `Get-XoVM | Get-XoVMSnapshot`), and work with multiple inputs (e.g. `Get-XoVM | Where-Object ... | Stop-XoVM`).
-7. Cmdlet output should be formatted by default (as seen when you type `dir`) without affecting pipelines. You can do this using .ps1xml files, `ViewDefinitions` and `PSObject.TypeNames`.
-8. Destructive cmdlets must support `-Confirm` (by default, with `ConfirmImpact`) and `-WhatIf`.
+4. All cmdlets should have "native PowerShell" documentation, accessible via Get-Help (with `.SYNOPSIS`, `.DESCRIPTION`, comments/parameter constraints, `Validate` and `ArgumentCompletions` etc.).
+5. Cmdlet output should be pipelineable (e.g. `Get-XoVM | Get-XoVMSnapshot`), and work with multiple inputs (e.g. `Get-XoVM | Where-Object ... | Stop-XoVM`).
+6. Cmdlet output should be formatted by default (as seen when you type `dir`) without affecting pipelines. You can do this using .ps1xml files, `ViewDefinitions` and `PSObject.TypeNames`.
+7. Destructive cmdlets must support `-Confirm` (by default, with `ConfirmImpact`) and `-WhatIf`.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -1,0 +1,6 @@
+Implementation notes
+--------------------
+
+- `ValueFromPipelineByPropertyName` and similar params are not bound in `begin{}`. Do all the filter/limit prep in `end{}` instead.
+- In general, try/catch should be reserved for cleanup, and the error handling should be controlled by `$ErrorActionPreference`.
+- Module-level variables should not be globals (e.g. by using `$Script:VariableName` instead).

--- a/src/host.ps1
+++ b/src/host.ps1
@@ -108,23 +108,6 @@ function Get-XoHost {
         }
 
         $params = @{ fields = $script:XO_HOST_FIELDS }
-
-        if ($PSCmdlet.ParameterSetName -eq "Filter") {
-            $AllFilters = $Filter
-
-            if ($PoolUuid) {
-                $AllFilters = "$AllFilters `$pool:$PoolUuid"
-            }
-
-            if ($AllFilters) {
-                Write-Verbose "Filter: $AllFilters"
-                $params["filter"] = $AllFilters
-            }
-        }
-
-        if ($Limit) {
-            $params["limit"] = $Limit
-        }
     }
 
     process {
@@ -137,6 +120,21 @@ function Get-XoHost {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            $AllFilters = $Filter
+
+            if ($PoolUuid) {
+                $AllFilters = "$AllFilters `$pool:$PoolUuid"
+            }
+
+            if ($AllFilters) {
+                Write-Verbose "Filter: $AllFilters"
+                $params["filter"] = $AllFilters
+            }
+
+            if ($Limit) {
+                $params["limit"] = $Limit
+            }
+
             try {
                 $uri = "$script:XoHost/rest/v0/hosts"
                 $hostsResponse = Invoke-XoRestMethod -Uri $uri -Body $params

--- a/src/message.ps1
+++ b/src/message.ps1
@@ -56,25 +56,6 @@ function Get-XoMessage {
         $params = @{
             fields = $script:XO_MESSAGE_FIELDS
         }
-
-        if ($PSCmdlet.ParameterSetName -eq "Filter") {
-            $AllFilters = $Filter
-
-            if ($Name) {
-                $AllFilters = "$AllFilters name:`"$Name`""
-            }
-
-            if ($AllFilters) {
-                $params["filter"] = $AllFilters
-            }
-        }
-
-        # numbers are not affected by Remove-XoEmptyValues
-        # having $Limit be in ParameterSetName = "MessageUuid" is quite nonsensical, but hopefully better than having
-        # a ton of ParameterSetNames.
-        if ($Limit) {
-            $params["limit"] = $Limit
-        }
     }
 
     process {
@@ -87,6 +68,22 @@ function Get-XoMessage {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            $AllFilters = $Filter
+
+            if ($Name) {
+                $AllFilters = "$AllFilters name:`"$Name`""
+            }
+
+            if ($AllFilters) {
+                $params["filter"] = $AllFilters
+            }
+
+            # having $Limit be in ParameterSetName = "MessageUuid" is quite nonsensical, but hopefully better than having
+            # a ton of ParameterSetNames.
+            if ($Limit) {
+                $params["limit"] = $Limit
+            }
+
             # the parentheses forces the resulting array to unpack, don't remove them!
             (Invoke-RestMethod -Uri "$script:XoHost/rest/v0/messages" @script:XoRestParameters -Body $params) | ConvertTo-XoMessageObject
         }

--- a/src/network.ps1
+++ b/src/network.ps1
@@ -55,28 +55,6 @@ function Get-XoNetwork {
         $params = @{
             fields = $script:XO_NETWORK_FIELDS
         }
-
-        if ($PSCmdlet.ParameterSetName -eq "Filter") {
-            $AllFilters = $Filter
-
-            if ($Name) {
-                $AllFilters = "$AllFilters name_label:`"$Name`""
-            }
-
-            if ($Tag) {
-                $tags = ($tag | ForEach-Object { "`"$_`"" }) -join " "
-                $AllFilters = "$AllFilters tags:($tags)"
-            }
-
-            $params = Remove-XoEmptyValues @{
-                filter = $AllFilters
-                fields = $script:XO_NETWORK_FIELDS
-            }
-        }
-
-        if ($Limit) {
-            $params["limit"] = $Limit
-        }
     }
 
     process {
@@ -89,6 +67,25 @@ function Get-XoNetwork {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            $AllFilters = $Filter
+
+            if ($Name) {
+                $AllFilters = "$AllFilters name_label:`"$Name`""
+            }
+
+            if ($Tag) {
+                $tags = ($tag | ForEach-Object { "`"$_`"" }) -join " "
+                $AllFilters = "$AllFilters tags:($tags)"
+            }
+
+            if ($AllFilters) {
+                $params["filter"] = $AllFilters
+            }
+
+            if ($Limit) {
+                $params["limit"] = $Limit
+            }
+
             (Invoke-RestMethod -Uri "$script:XoHost/rest/v0/networks" @script:XoRestParameters -Body $params) | ConvertTo-XoNetworkObject
         }
     }

--- a/src/pif.ps1
+++ b/src/pif.ps1
@@ -55,24 +55,6 @@ function Get-XoPif {
             fields = $script:XO_PIF_FIELDS
         }
 
-        if ($PSCmdlet.ParameterSetName -eq "Filter") {
-            $AllFilters = $Filter
-
-            if ($Name) {
-                $AllFilters = "$AllFilters name_label:`"$Name`""
-            }
-
-            if ($Tag) {
-                $tags = ($tag | ForEach-Object { "`"$_`"" }) -join " "
-                $AllFilters = "$AllFilters tags:($tags)"
-            }
-
-            $params = Remove-XoEmptyValues @{
-                filter = $AllFilters
-                fields = $script:XO_PIF_FIELDS
-            }
-        }
-
         if ($Limit) {
             $params["limit"] = $Limit
         }
@@ -88,6 +70,21 @@ function Get-XoPif {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            $AllFilters = $Filter
+
+            if ($Name) {
+                $AllFilters = "$AllFilters name_label:`"$Name`""
+            }
+
+            if ($Tag) {
+                $tags = ($tag | ForEach-Object { "`"$_`"" }) -join " "
+                $AllFilters = "$AllFilters tags:($tags)"
+            }
+
+            if ($AllFilters) {
+                $params["filter"] = $AllFilters
+            }
+
             (Invoke-RestMethod -Uri "$script:XoHost/rest/v0/pifs" @script:XoRestParameters -Body $params) | ConvertTo-XoPifObject
         }
     }

--- a/src/pool.ps1
+++ b/src/pool.ps1
@@ -56,7 +56,17 @@ function Get-XoPool {
         $params = @{
             fields = $script:XO_POOL_FIELDS
         }
+    }
 
+    process {
+        if ($PSCmdlet.ParameterSetName -eq "PoolUuid") {
+            foreach ($id in $PoolUuid) {
+                ConvertTo-XoPoolObject (Invoke-RestMethod -Uri "$script:XoHost/rest/v0/pools/$id" @script:XoRestParameters -Body $params)
+            }
+        }
+    }
+
+    end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
             $AllFilters = $Filter
 
@@ -72,23 +82,11 @@ function Get-XoPool {
             if ($AllFilters) {
                 $params["filter"] = $AllFilters
             }
-        }
 
-        if ($Limit) {
-            $params["limit"] = $Limit
-        }
-    }
-
-    process {
-        if ($PSCmdlet.ParameterSetName -eq "PoolUuid") {
-            foreach ($id in $PoolUuid) {
-                ConvertTo-XoPoolObject (Invoke-RestMethod -Uri "$script:XoHost/rest/v0/pools/$id" @script:XoRestParameters -Body $params)
+            if ($Limit) {
+                $params["limit"] = $Limit
             }
-        }
-    }
 
-    end {
-        if ($PSCmdlet.ParameterSetName -eq "Filter") {
             (Invoke-RestMethod -Uri "$script:XoHost/rest/v0/pools" @script:XoRestParameters -Body $params) | ConvertTo-XoPoolObject
         }
     }

--- a/src/server.ps1
+++ b/src/server.ps1
@@ -114,17 +114,6 @@ function Get-XoServer {
         }
 
         $params = @{ fields = $script:XO_SERVER_FIELDS }
-
-        if ($PSCmdlet.ParameterSetName -eq "Filter" -and $Filter) {
-            $params['filter'] = $Filter
-        }
-
-        if ($Limit -ne 0 -and $PSCmdlet.ParameterSetName -eq "Filter") {
-            $params['limit'] = $Limit
-            if (!$PSBoundParameters.ContainsKey('Limit')) {
-                Write-Warning "No limit specified. Using default limit of $Limit. Use -Limit 0 for unlimited results."
-            }
-        }
     }
 
     process {
@@ -137,6 +126,16 @@ function Get-XoServer {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            $AllFilters = $Filter
+
+            if ($AllFilters) {
+                $params["filter"] = $AllFilters
+            }
+
+            if ($Limit) {
+                $params["limit"] = $Limit
+            }
+
             try {
                 Write-Verbose "Getting servers with parameters: $($params | ConvertTo-Json -Compress)"
                 $uri = "$script:XoHost/rest/v0/servers"

--- a/src/session.ps1
+++ b/src/session.ps1
@@ -63,6 +63,9 @@ function Connect-XoSession {
         [string]$Token,
 
         [Parameter()]
+        [int]$Limit,
+
+        [Parameter()]
         [switch]$SaveCredentials,
 
         [Parameter()]
@@ -72,8 +75,14 @@ function Connect-XoSession {
     $script:XoHost = $HostName.TrimEnd("/")
     Write-Verbose "Connecting to Xen Orchestra at $script:XoHost"
 
-    # Reset session limit to default value on new connection
-    $script:XoSessionLimit = $script:XO_DEFAULT_LIMIT
+    if ($PSBoundParameters.ContainsKey('Limit')) {
+        $script:XoSessionLimit = $Limit
+    }
+    else {
+        Write-Warning "No limit specified. Using default limit of $script:XO_DEFAULT_LIMIT. Use -Limit 0 for unlimited results."
+        # Reset session limit to default value on new connection
+        $script:XoSessionLimit = $script:XO_DEFAULT_LIMIT
+    }
 
     $needsSave = $SaveCredentials
 

--- a/src/sr.ps1
+++ b/src/sr.ps1
@@ -100,13 +100,6 @@ function Get-XoSr {
         $params = @{
             fields = $script:XO_SR_FIELDS
         }
-
-        if ($Limit -ne 0 -and $PSCmdlet.ParameterSetName -eq "Filter") {
-            $params['limit'] = $Limit
-            if (!$PSBoundParameters.ContainsKey('Limit')) {
-                Write-Warning "No limit specified. Using default limit of $Limit. Use -Limit 0 for unlimited results."
-            }
-        }
     }
 
     process {
@@ -119,6 +112,10 @@ function Get-XoSr {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            if ($Limit) {
+                $params['limit'] = $Limit
+            }
+
             try {
                 Write-Verbose "Getting SRs with parameters: $($params | ConvertTo-Json -Compress)"
                 $uri = "$script:XoHost/rest/v0/srs"

--- a/src/task.ps1
+++ b/src/task.ps1
@@ -176,17 +176,6 @@ function Get-XoTask {
         $params = @{
             fields = $script:XO_TASK_FIELDS
         }
-
-        if ($PSCmdlet.ParameterSetName -eq "Filter" -and $PSBoundParameters.ContainsKey('Status')) {
-            $params['filter'] = $Status
-        }
-
-        if ($PSCmdlet.ParameterSetName -eq "Filter" -and $Limit -ne 0) {
-            $params['limit'] = $Limit
-            if (!$PSBoundParameters.ContainsKey('Limit')) {
-                Write-Warning "No limit specified. Using default limit of $Limit. Use -Limit 0 for unlimited results."
-            }
-        }
     }
 
     process {
@@ -199,6 +188,14 @@ function Get-XoTask {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            if ($Status) {
+                $params['filter'] = $Status
+            }
+
+            if ($Limit) {
+                $params['limit'] = $Limit
+            }
+
             try {
                 Write-Verbose "Getting tasks with parameters: $($params | ConvertTo-Json -Compress)"
                 $uri = "$script:XoHost/rest/v0/tasks"

--- a/src/vbd.ps1
+++ b/src/vbd.ps1
@@ -54,28 +54,6 @@ function Get-XoVbd {
         $params = @{
             fields = $script:XO_VBD_FIELDS
         }
-
-        if ($PSCmdlet.ParameterSetName -eq "Filter") {
-            $AllFilters = $Filter
-
-            if ($Name) {
-                $AllFilters = "$AllFilters name_label:`"$Name`""
-            }
-
-            if ($Tag) {
-                $tags = ($tag | ForEach-Object { "`"$_`"" }) -join " "
-                $AllFilters = "$AllFilters tags:($tags)"
-            }
-
-            $params = Remove-XoEmptyValues @{
-                filter = $AllFilters
-                fields = $script:XO_VBD_FIELDS
-            }
-        }
-
-        if ($Limit) {
-            $params["limit"] = $Limit
-        }
     }
 
     process {
@@ -88,6 +66,25 @@ function Get-XoVbd {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            $AllFilters = $Filter
+
+            if ($Name) {
+                $AllFilters = "$AllFilters name_label:`"$Name`""
+            }
+
+            if ($Tag) {
+                $tags = ($tag | ForEach-Object { "`"$_`"" }) -join " "
+                $AllFilters = "$AllFilters tags:($tags)"
+            }
+
+            if ($AllFilters) {
+                $params["filter"] = $AllFilters
+            }
+
+            if ($Limit) {
+                $params["limit"] = $Limit
+            }
+
             (Invoke-RestMethod -Uri "$script:XoHost/rest/v0/vbds" @script:XoRestParameters -Body $params) | ConvertTo-XoVbdObject
         }
     }

--- a/src/vdi-snapshot.ps1
+++ b/src/vdi-snapshot.ps1
@@ -100,17 +100,6 @@ function Get-XoVdiSnapshot {
         }
 
         $params = @{ fields = $script:XO_VDI_SNAPSHOT_FIELDS }
-
-        if ($Filter) {
-            $params['filter'] = $Filter
-        }
-
-        if ($Limit -ne 0 -and $PSCmdlet.ParameterSetName -eq "Filter") {
-            $params['limit'] = $Limit
-            if (!$PSBoundParameters.ContainsKey('Limit')) {
-                Write-Warning "No limit specified. Using default limit of $Limit. Use -Limit 0 for unlimited results."
-            }
-        }
     }
 
     process {
@@ -123,6 +112,14 @@ function Get-XoVdiSnapshot {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            if ($Filter) {
+                $params['filter'] = $Filter
+            }
+
+            if ($Limit) {
+                $params['limit'] = $Limit
+            }
+
             try {
                 Write-Verbose "Getting VDI snapshots with parameters: $($params | ConvertTo-Json -Compress)"
                 $uri = "$script:XoHost/rest/v0/vdi-snapshots"

--- a/src/vdi.ps1
+++ b/src/vdi.ps1
@@ -110,27 +110,6 @@ function Get-XoVdi {
         }
 
         $params = @{ fields = $script:XO_VDI_FIELDS }
-
-        $filterParts = @()
-
-        if ($SrUuid) {
-            $filterParts += "sr_uuid:$SrUuid"
-        }
-
-        if ($Filter) {
-            $filterParts += $Filter
-        }
-
-        if ($filterParts.Count -gt 0) {
-            $params['filter'] = $filterParts -join " "
-        }
-
-        if ($Limit -ne 0) {
-            $params['limit'] = $Limit
-            if (!$PSBoundParameters.ContainsKey('Limit')) {
-                Write-Warning "No limit specified. Using default limit of $Limit. Use -Limit 0 for unlimited results."
-            }
-        }
     }
 
     process {
@@ -143,6 +122,24 @@ function Get-XoVdi {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            $filterParts = @()
+
+            if ($SrUuid) {
+                $filterParts += "sr_uuid:$SrUuid"
+            }
+
+            if ($Filter) {
+                $filterParts += $Filter
+            }
+
+            if ($filterParts.Count -gt 0) {
+                $params['filter'] = $filterParts -join " "
+            }
+
+            if ($Limit) {
+                $params['limit'] = $Limit
+            }
+
             try {
                 Write-Verbose "Getting VDIs with parameters: $($params | ConvertTo-Json -Compress)"
                 $uri = "$script:XoHost/rest/v0/vdis"

--- a/src/vif.ps1
+++ b/src/vif.ps1
@@ -54,28 +54,6 @@ function Get-XoVif {
         $params = @{
             fields = $script:XO_VIF_FIELDS
         }
-
-        if ($PSCmdlet.ParameterSetName -eq "Filter") {
-            $AllFilters = $Filter
-
-            if ($Name) {
-                $AllFilters = "$AllFilters name_label:`"$Name`""
-            }
-
-            if ($Tag) {
-                $tags = ($tag | ForEach-Object { "`"$_`"" }) -join " "
-                $AllFilters = "$AllFilters tags:($tags)"
-            }
-
-            $params = Remove-XoEmptyValues @{
-                filter = $AllFilters
-                fields = $script:XO_VIF_FIELDS
-            }
-        }
-
-        if ($Limit) {
-            $params["limit"] = $Limit
-        }
     }
 
     process {
@@ -88,6 +66,25 @@ function Get-XoVif {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            $AllFilters = $Filter
+
+            if ($Name) {
+                $AllFilters = "$AllFilters name_label:`"$Name`""
+            }
+
+            if ($Tag) {
+                $tags = ($tag | ForEach-Object { "`"$_`"" }) -join " "
+                $AllFilters = "$AllFilters tags:($tags)"
+            }
+
+            if ($AllFilters) {
+                $params["filter"] = $AllFilters
+            }
+
+            if ($Limit) {
+                $params["limit"] = $Limit
+            }
+
             (Invoke-RestMethod -Uri "$script:XoHost/rest/v0/vifs" @script:XoRestParameters -Body $params) | ConvertTo-XoVifObject
         }
     }

--- a/src/vm-snapshot.ps1
+++ b/src/vm-snapshot.ps1
@@ -87,17 +87,6 @@ function Get-XoVmSnapshot {
         }
 
         $params = @{ fields = $script:XO_VM_SNAPSHOT_FIELDS }
-
-        if ($PSBoundParameters.ContainsKey('Filter')) {
-            $params.filter = $Filter
-        }
-
-        if ($Limit -ne 0) {
-            $params.limit = $Limit
-            if (!$PSBoundParameters.ContainsKey('Limit')) {
-                Write-Warning "No limit specified. Using default limit of $Limit. Use -Limit 0 for unlimited results."
-            }
-        }
     }
 
     process {
@@ -117,6 +106,14 @@ function Get-XoVmSnapshot {
 
     end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
+            if ($Filter) {
+                $params["filter"] = $Filter
+            }
+
+            if ($Limit) {
+                $params["limit"] = $Limit
+            }
+
             try {
                 $uri = "$script:XoHost/rest/v0/vm-snapshots"
                 Write-Verbose "Getting VM snapshots from $uri with parameters: $($params | ConvertTo-Json -Compress)"

--- a/src/vm.ps1
+++ b/src/vm.ps1
@@ -133,7 +133,17 @@ function Get-XoVm {
         }
 
         $params = @{ fields = $script:XO_VM_FIELDS }
+    }
 
+    process {
+        if ($PSCmdlet.ParameterSetName -eq "VmUuid") {
+            foreach ($id in $VmUuid) {
+                Get-XoSingleVmById -VmUuid $id
+            }
+        }
+    }
+
+    end {
         if ($PSCmdlet.ParameterSetName -eq "Filter") {
             $AllFilters = $Filter
 
@@ -157,23 +167,11 @@ function Get-XoVm {
                 Write-Verbose "Filter: $AllFilters"
                 $params["filter"] = $AllFilters
             }
-        }
 
-        if ($Limit) {
-            $params['limit'] = $Limit
-        }
-    }
-
-    process {
-        if ($PSCmdlet.ParameterSetName -eq "VmUuid") {
-            foreach ($id in $VmUuid) {
-                Get-XoSingleVmById -VmUuid $id
+            if ($Limit) {
+                $params['limit'] = $Limit
             }
-        }
-    }
 
-    end {
-        if ($PSCmdlet.ParameterSetName -eq "Filter") {
             try {
                 $uri = "$script:XoHost/rest/v0/vms"
                 Write-Verbose "Getting VMs from $uri with parameters: $($params | ConvertTo-Json -Compress)"


### PR DESCRIPTION
- `ValueFromPipelineByPropertyName` and similar params are not bound in `begin{}`. Do all the filter/limit prep in `end{}` instead.
- Only warn about limit once at connection instead of every query.

This ensures pipelines between different types, e.g. `Get-XoPool -Filter "..." | Get-XoHost -Filter "..." | Get-XoVm` work normally.